### PR TITLE
Get deposit id for across from settlement tx

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@cowprotocol/cow-sdk": "6.0.0-RC.17",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.19",
     "axios": "^1.7.9",
     "dotenv": "^16.4.5",
     "ethers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@cowprotocol/cow-sdk": "6.0.0-RC.7",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.10",
     "axios": "^1.7.9",
     "dotenv": "^16.4.5",
     "ethers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@cowprotocol/cow-sdk": "6.0.0-RC.10",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.13",
     "axios": "^1.7.9",
     "dotenv": "^16.4.5",
     "ethers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@cowprotocol/cow-sdk": "6.0.0-RC.13",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.17",
     "axios": "^1.7.9",
     "dotenv": "^16.4.5",
     "ethers": "^5.7.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,10 +63,10 @@ const JOBS: (() => Promise<unknown>)[] = [
   // swapAndBridgeSwapsIo,
 
   // approveTokenArbitrum,
-  swapAndBridgeAccrossArbitrum,
+  // swapAndBridgeAccrossArbitrum,
   // swapAndBridgeAccrossMainnet,
 
-  // swapAndBridgeSdk,
+  swapAndBridgeSdk,
 ];
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,8 @@ import { run as approveTokenArbitrum } from "./scripts/arbitrum/approveTokenArbi
 import { run as swapAndBridgeAccrossArbitrum } from "./scripts/bridging/swapAndBridgeAccrossArbitrum";
 import { run as swapAndBridgeAccrossMainnet } from "./scripts/bridging/swapAndBridgeAccrossMainnet";
 import { run as swapAndBridgeSdk } from "./scripts/bridging/swapAndBridgeSdk";
-import { run as getQuote } from "./orderbook/getQuote";
+import { run as getOrderbookQuote } from "./orderbook/getQuote";
+import { run as getTradingQuote } from "./scripts/trading/getQuote";
 dotenv.config();
 
 // Just to dev things easily using watch-mode  :)
@@ -68,7 +69,8 @@ const JOBS: (() => Promise<unknown>)[] = [
   // swapAndBridgeAccrossMainnet,
 
   // swapAndBridgeSdk,
-  getQuote,
+  // getOrderbookQuote,
+  getTradingQuote,
 ];
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { run as approveTokenArbitrum } from "./scripts/arbitrum/approveTokenArbi
 import { run as swapAndBridgeAccrossArbitrum } from "./scripts/bridging/swapAndBridgeAccrossArbitrum";
 import { run as swapAndBridgeAccrossMainnet } from "./scripts/bridging/swapAndBridgeAccrossMainnet";
 import { run as swapAndBridgeSdk } from "./scripts/bridging/swapAndBridgeSdk";
+import { run as getQuote } from "./orderbook/getQuote";
 dotenv.config();
 
 // Just to dev things easily using watch-mode  :)
@@ -66,7 +67,8 @@ const JOBS: (() => Promise<unknown>)[] = [
   // swapAndBridgeAccrossArbitrum,
   // swapAndBridgeAccrossMainnet,
 
-  swapAndBridgeSdk,
+  // swapAndBridgeSdk,
+  getQuote,
 ];
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,9 +69,9 @@ const JOBS: (() => Promise<unknown>)[] = [
   // swapAndBridgeAccrossArbitrum,
   // swapAndBridgeAccrossMainnet,
 
-  // swapAndBridgeSdk,
+  swapAndBridgeSdk,
   // getOrderbookQuote,
-  getOrderbookQuoteWithAppData,
+  // getOrderbookQuoteWithAppData,
   // getTradingQuote,
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { run as swapAndBridgeAccrossArbitrum } from "./scripts/bridging/swapAndB
 import { run as swapAndBridgeAccrossMainnet } from "./scripts/bridging/swapAndBridgeAccrossMainnet";
 import { run as swapAndBridgeSdk } from "./scripts/bridging/swapAndBridgeSdk";
 import { run as getOrderbookQuote } from "./orderbook/getQuote";
+import { run as getOrderbookQuoteWithAppData } from "./orderbook/getQuoteWithAppData";
 import { run as getTradingQuote } from "./scripts/trading/getQuote";
 dotenv.config();
 
@@ -70,7 +71,8 @@ const JOBS: (() => Promise<unknown>)[] = [
 
   // swapAndBridgeSdk,
   // getOrderbookQuote,
-  getTradingQuote,
+  getOrderbookQuoteWithAppData,
+  // getTradingQuote,
 ];
 
 async function main() {

--- a/src/orderbook/getQuote.ts
+++ b/src/orderbook/getQuote.ts
@@ -1,0 +1,28 @@
+import {
+  OrderBookApi,
+  OrderQuoteSideKindSell,
+  PriceQuality,
+  SigningScheme,
+  SupportedChainId,
+} from "@cowprotocol/cow-sdk";
+
+export async function run() {
+  const orderBookApi = new OrderBookApi({
+    chainId: SupportedChainId.ARBITRUM_ONE,
+  });
+
+  const quote = await orderBookApi.getQuote({
+    kind: OrderQuoteSideKindSell.SELL,
+    from: "0x016f34D4f2578c3e9DFfC3f2b811Ba30c0c9e7f3",
+    sellToken: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    buyToken: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+    receiver: "0x016f34D4f2578c3e9DFfC3f2b811Ba30c0c9e7f3",
+    validFor: 1800,
+    priceQuality: PriceQuality.OPTIMAL,
+    signingScheme: SigningScheme.EIP712,
+
+    sellAmountBeforeFee: "5000000",
+  });
+
+  console.log("quote result", quote);
+}

--- a/src/orderbook/getQuoteWithAppData.ts
+++ b/src/orderbook/getQuoteWithAppData.ts
@@ -4,15 +4,27 @@ import {
   PriceQuality,
   SigningScheme,
   SupportedChainId,
-  enableLogging,
+  buildAppData,
+  generateAppDataFromDoc,
 } from "@cowprotocol/cow-sdk";
+import { APP_CODE } from "../const";
 
 export async function run() {
   const orderBookApi = new OrderBookApi({
     chainId: SupportedChainId.ARBITRUM_ONE,
   });
 
-  enableLogging(true);
+  const kind = OrderQuoteSideKindSell.SELL;
+
+  // const appData = await buildAppData({
+  //   appCode: APP_CODE,
+  //   orderClass: "market",
+  //   slippageBps: 100,
+  //   partnerFee: {
+  //     bps: 50,
+  //     recipient: "0x016f34D4f2578c3e9DFfC3f2b811Ba30c0c9e7f3",
+  //   },
+  // });
 
   const quote = await orderBookApi.getQuote({
     kind: OrderQuoteSideKindSell.SELL,
@@ -24,6 +36,10 @@ export async function run() {
     priceQuality: PriceQuality.OPTIMAL,
     signingScheme: SigningScheme.EIP712,
     sellAmountBeforeFee: "5000000",
+    appData:
+      '{"appCode":"swap-n-bridge","metadata":{"hooks":{"post":[{"callData":"0x00","gasLimit":"110000","target":"0x0000000000000000000000000000000000000000"}]}},"version":"1.3.0"}',
+    appDataHash:
+      "0xc23b1518b9946714c0d396392a308bbbc5cf3a19a0bcace01ef9a8d222ca5f95",
   });
 
   console.log("quote result", quote);

--- a/src/scripts/bridging/swapAndBridgeSdk.ts
+++ b/src/scripts/bridging/swapAndBridgeSdk.ts
@@ -1,0 +1,152 @@
+import { base, arbitrum, APP_CODE } from "../../const";
+
+import {
+  SupportedChainId,
+  BridgingSdk,
+  AcrossBridgeProvider,
+  QuoteBridgeRequest,
+  OrderKind,
+  isBridgeQuoteAndPost,
+  AccountAddress,
+} from "@cowprotocol/cow-sdk";
+import { ethers } from "ethers";
+
+import { confirm, getWallet, jsonReplacer } from "../../utils";
+
+export async function run() {
+  // Sell token (USDC in Arbitrum)
+  const sellTokenChainId = SupportedChainId.ARBITRUM_ONE;
+  const sellTokenAddress = arbitrum.USDC_ADDRESS;
+  const sellTokenDecimals = 6;
+
+  // Buy token (WETH in Base)
+  const buyTokenChainId = SupportedChainId.BASE;
+  const buyTokenAddress = base.WETH_ADDRESS;
+  const buyTokenDecimals = 18;
+
+  // Amount to sell
+  const sellAmount = ethers.utils.parseUnits("5", sellTokenDecimals).toBigInt();
+
+  // Get wallet
+  const wallet = await getWallet(sellTokenChainId);
+
+  // Initialize the Across bridge provider
+  const acrossBridgeProvider = new AcrossBridgeProvider();
+
+  // Initialize the SDK with the wallet
+  const sdk = new BridgingSdk({
+    providers: [acrossBridgeProvider],
+  });
+
+  const parameters: QuoteBridgeRequest = {
+    kind: OrderKind.SELL,
+
+    sellTokenChainId,
+    sellTokenAddress,
+    sellTokenDecimals,
+
+    buyTokenChainId,
+    buyTokenAddress,
+    buyTokenDecimals,
+
+    amount: sellAmount,
+    appCode: APP_CODE,
+
+    // TODO: Sort this mess
+    receiver: wallet.address,
+    signer: wallet,
+    account: wallet.address as AccountAddress, // FIXME: Why is this needed
+
+    partiallyFillable: false,
+    slippageBps: 50,
+  };
+
+  console.log(
+    "🕣 Getting quote...",
+    JSON.stringify(parameters, jsonReplacer, 2)
+  );
+
+  const quote = await sdk.getQuote(parameters);
+  if (!isBridgeQuoteAndPost(quote))
+    throw new Error("Quote is not a bridge quote");
+
+  // After the assertion, we can safely destructure the quote
+  const { postSwapOrderFromQuote, bridge, swap } = quote;
+
+  const swapAmount = swap.amountsAndCosts;
+  const bridgeAmount = bridge.amountsAndCosts;
+
+  console.log(`
+Swap details:
+  - Sell
+      - Token: ${swap.tradeParameters.sellToken} (${
+    swap.tradeParameters.sellTokenDecimals
+  })
+      - Amount: ${swapAmount.afterNetworkCosts.sellAmount}
+  - Buy (intermediate token))
+      - Token: ${swap.tradeParameters.buyToken} (${
+    swap.tradeParameters.buyTokenDecimals
+  })
+      - Est. Receive: ${swapAmount.afterPartnerFees.buyAmount}
+      - Min. Receive: ${swapAmount.afterSlippage.buyAmount}
+  - Network fee: ${swapAmount.costs.networkFee}
+  - Slippage: ${swap.tradeParameters.slippageBps ?? "default"}
+  - Receiver: ${swap.tradeParameters.receiver}
+
+Bridge details:
+   - Bridge provider:
+       - Name: ${bridge.providerInfo.name}
+       - Logo: ${bridge.providerInfo.logoUrl}
+   - Bridged token (intermediate token)
+       - Token: ${bridge.tradeParameters.sellTokenAddress} (${
+    bridge.tradeParameters.sellTokenDecimals
+  })
+       - Amount: ${bridgeAmount.beforeFee.sellAmount}
+   - Buy:
+       - Token: ${bridge.tradeParameters.buyTokenAddress} (${
+    bridge.tradeParameters.buyTokenDecimals
+  })
+       - Est. Receive (buy token): ${bridgeAmount.afterFee.buyAmount}
+       - Min. Receive (buy token): ${bridgeAmount.afterSlippage.buyAmount}
+   - Bridging fee: ${bridgeAmount.costs.bridgingFee}
+   - Slippage: ${bridgeAmount.slippageBps}
+   - Recipient: ${bridge.tradeParameters.receiver}
+`);
+
+  const sellAmountFormatted = ethers.utils.formatUnits(
+    sellAmount,
+    sellTokenDecimals
+  );
+
+  const minReceiveBuyToken = ethers.utils.formatUnits(
+    bridgeAmount.afterSlippage.buyAmount,
+    buyTokenDecimals
+  );
+
+  const confirmed = await confirm(
+    `Sell ${sellAmountFormatted} USDC (Arbitrum) for receive at least ${minReceiveBuyToken} WETH (Base). ok?`
+  );
+  if (!confirmed) {
+    console.log("🚫 Aborted");
+    return;
+  }
+
+  // Post the order
+  const orderId = await postSwapOrderFromQuote();
+
+  // Print the order creation
+  console.log(
+    `ℹ️ Order created, id: https://explorer.cow.fi/orders/${orderId}?tab=overview`
+  );
+
+  // Wait for the bridge start
+  console.log("🕣 Waiting for the bridge to start...");
+  console.log("🔗 Across link: <URL>");
+  // TODO: Implement
+
+  // Wait for the bridging to be completed
+  console.log("🕣 Waiting for the bridging to be completed...");
+  // TODO: Implement
+
+  console.log(`🎉 The WETH is now waiting for you in Base`);
+}

--- a/src/scripts/bridging/swapAndBridgeSdk.ts
+++ b/src/scripts/bridging/swapAndBridgeSdk.ts
@@ -8,6 +8,7 @@ import {
   OrderKind,
   isBridgeQuoteAndPost,
   AccountAddress,
+  TradingSdk,
 } from "@cowprotocol/cow-sdk";
 import { ethers } from "ethers";
 
@@ -36,6 +37,7 @@ export async function run() {
   // Initialize the SDK with the wallet
   const sdk = new BridgingSdk({
     providers: [acrossBridgeProvider],
+    tradingSdk: new TradingSdk({}, { enableLogging: true }),
   });
 
   const parameters: QuoteBridgeRequest = {

--- a/src/scripts/trading/getQuote.ts
+++ b/src/scripts/trading/getQuote.ts
@@ -1,0 +1,29 @@
+import { base, arbitrum, APP_CODE } from "../../const";
+
+import { SupportedChainId, OrderKind, TradingSdk } from "@cowprotocol/cow-sdk";
+import { ethers } from "ethers";
+
+import { getWallet, jsonReplacer } from "../../utils";
+
+export async function run() {
+  // Get wallet
+  const sellTokenChainId = SupportedChainId.ARBITRUM_ONE;
+  const wallet = await getWallet(sellTokenChainId);
+  const sellTokenDecimals = 6;
+
+  // Initialize the SDK with the wallet
+  const sdk = new TradingSdk({ signer: wallet, appCode: APP_CODE });
+  const quote = await sdk.getQuote({
+    kind: OrderKind.SELL,
+    chainId: sellTokenChainId,
+    sellToken: arbitrum.USDC_ADDRESS,
+    sellTokenDecimals: 6,
+    buyToken: arbitrum.USDT_ADDRESS,
+    buyTokenDecimals: 6,
+    receiver: wallet.address,
+    amount: ethers.utils.parseUnits("5", sellTokenDecimals).toString(),
+    validFor: 1800,
+  });
+
+  console.log(`🎉 quote`, JSON.stringify(quote, jsonReplacer, 2));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,10 +42,10 @@
   resolved "https://registry.npmjs.org/@cowprotocol/contracts/-/contracts-1.7.0.tgz"
   integrity sha512-tog/0igLaWZv6kK30+aFJ267+yNyMINx6qDHaJQFKZs051XUXnzNFlZgCEfICwDz/821XYjZxOnNbe449tgD5w==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.10":
-  version "6.0.0-RC.10"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.10.tgz#df4822436f95691739b05fa01ac2e0aec3ab1cae"
-  integrity sha512-KUWfqIAQNtaORIFUUlmzmOm5Cx4xwSYi02n5PqnaFZB/lqVqo1q2O6CajDYLt7zQEHwv6KWGqwmhhxNSZp0/gA==
+"@cowprotocol/cow-sdk@6.0.0-RC.13":
+  version "6.0.0-RC.13"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.13.tgz#fd7f98d0a0e1ad5558d7c5e28b27a65d3fc6ae1b"
+  integrity sha512-Og3ql7eb26CW1b/Lur4W8CqaI9E3KHA+OrqIapTMR6PyLqwhM4kU5r5epJ4iiXN3cww6/BTfuqPllknTcESr/w==
   dependencies:
     "@cowprotocol/app-data" "^2.4.0"
     "@cowprotocol/contracts" "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,10 +42,10 @@
   resolved "https://registry.npmjs.org/@cowprotocol/contracts/-/contracts-1.7.0.tgz"
   integrity sha512-tog/0igLaWZv6kK30+aFJ267+yNyMINx6qDHaJQFKZs051XUXnzNFlZgCEfICwDz/821XYjZxOnNbe449tgD5w==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.18":
-  version "6.0.0-RC.18"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.18.tgz#2912708c3b1489b79dec9b45afad860f1d1a599c"
-  integrity sha512-aNO7hV4hd6VIDYUyd6mjUOlSUZItuMPXuFqqxBcloN5P7HsWcB4cceyX/W+9A8WyNGxXpJA5Ods+Cv2vicb3+w==
+"@cowprotocol/cow-sdk@6.0.0-RC.19":
+  version "6.0.0-RC.19"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.19.tgz#20c1b1d738d1b86ee06041c54e856a63b364be37"
+  integrity sha512-3pUGyCp3afMuyKmmG9X6n66/nnxqbNFsj3XFJCFARl2R1wTjw6dP8ta8cBfQx6HYr/ySkFOEQOUFJbuHv7ZkyA==
   dependencies:
     "@cowprotocol/app-data" "^2.4.0"
     "@cowprotocol/contracts" "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,10 +42,10 @@
   resolved "https://registry.npmjs.org/@cowprotocol/contracts/-/contracts-1.7.0.tgz"
   integrity sha512-tog/0igLaWZv6kK30+aFJ267+yNyMINx6qDHaJQFKZs051XUXnzNFlZgCEfICwDz/821XYjZxOnNbe449tgD5w==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.16":
-  version "6.0.0-RC.16"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.16.tgz#59a7ee0228a6fd5a3c236e2e6da8f764338c0a33"
-  integrity sha512-tuGsVtNatqM9+sPJvRb4oBHnVxKX+h6+VP4pJxBvd3HxL9kAgBIf8HcOa1BDWupWHd2Uo3QWdXFdjuJI/azisg==
+"@cowprotocol/cow-sdk@6.0.0-RC.18":
+  version "6.0.0-RC.18"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.18.tgz#2912708c3b1489b79dec9b45afad860f1d1a599c"
+  integrity sha512-aNO7hV4hd6VIDYUyd6mjUOlSUZItuMPXuFqqxBcloN5P7HsWcB4cceyX/W+9A8WyNGxXpJA5Ods+Cv2vicb3+w==
   dependencies:
     "@cowprotocol/app-data" "^2.4.0"
     "@cowprotocol/contracts" "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,10 +42,10 @@
   resolved "https://registry.npmjs.org/@cowprotocol/contracts/-/contracts-1.7.0.tgz"
   integrity sha512-tog/0igLaWZv6kK30+aFJ267+yNyMINx6qDHaJQFKZs051XUXnzNFlZgCEfICwDz/821XYjZxOnNbe449tgD5w==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.7":
-  version "6.0.0-RC.7"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.7.tgz#175666db8f2187b02aa0cd32a073e7cbe5c6c34a"
-  integrity sha512-Vd89n+NjWvqzY1uNwcIboy+C/xtlAcwkTt6dRSZ2ocLBDT7Hy3frrJbbuJZ6gaqnnfJHEjP8slRMTkLhtZyAsA==
+"@cowprotocol/cow-sdk@6.0.0-RC.10":
+  version "6.0.0-RC.10"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.10.tgz#df4822436f95691739b05fa01ac2e0aec3ab1cae"
+  integrity sha512-KUWfqIAQNtaORIFUUlmzmOm5Cx4xwSYi02n5PqnaFZB/lqVqo1q2O6CajDYLt7zQEHwv6KWGqwmhhxNSZp0/gA==
   dependencies:
     "@cowprotocol/app-data" "^2.4.0"
     "@cowprotocol/contracts" "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,10 +42,10 @@
   resolved "https://registry.npmjs.org/@cowprotocol/contracts/-/contracts-1.7.0.tgz"
   integrity sha512-tog/0igLaWZv6kK30+aFJ267+yNyMINx6qDHaJQFKZs051XUXnzNFlZgCEfICwDz/821XYjZxOnNbe449tgD5w==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.13":
-  version "6.0.0-RC.13"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.13.tgz#fd7f98d0a0e1ad5558d7c5e28b27a65d3fc6ae1b"
-  integrity sha512-Og3ql7eb26CW1b/Lur4W8CqaI9E3KHA+OrqIapTMR6PyLqwhM4kU5r5epJ4iiXN3cww6/BTfuqPllknTcESr/w==
+"@cowprotocol/cow-sdk@6.0.0-RC.16":
+  version "6.0.0-RC.16"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.16.tgz#59a7ee0228a6fd5a3c236e2e6da8f764338c0a33"
+  integrity sha512-tuGsVtNatqM9+sPJvRb4oBHnVxKX+h6+VP4pJxBvd3HxL9kAgBIf8HcOa1BDWupWHd2Uo3QWdXFdjuJI/azisg==
   dependencies:
     "@cowprotocol/app-data" "^2.4.0"
     "@cowprotocol/contracts" "^1.6.0"


### PR DESCRIPTION
This PR obtains the deposit id from across bridging using just the events of the settlement and the orderbook API.

Input:
- tx hash of the settlement
- orderId of the order you want to get the `depositId` into the across spook contract
- chainId

Main algorithm is:
- Get all across deposits events (ordered by `logindex`)
- Get all trade events in the settlement (ordered by `logindex`)
- Extract the orderId from the trades, fetch the order details from Orderbook API
- Filter the orders, leaving only the ones that have a post-hook to bridge using across
- Get the relative position of the `orderId` you are particularly interested from the settlement. Use that relative order to return the deposit details.