### PR TITLE
chore: snippet to get the order id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { run as getOrderbookQuote } from "./orderbook/getQuote";
 import { run as getOrderbookQuoteWithAppData } from "./orderbook/getQuoteWithAppData";
 import { run as getTradingQuote } from "./scripts/trading/getQuote";
 import { run as getAcrossBridgingId } from "./scripts/bridging/getAcrossBridgingId";
+import { run as getEthFlowId } from "./scripts/ethflow/getEthFlowId";
 dotenv.config();
 
 // Just to dev things easily using watch-mode  :)
@@ -75,7 +76,8 @@ const JOBS: (() => Promise<unknown>)[] = [
   // getOrderbookQuoteWithAppData,
   // getTradingQuote,
 
-  getAcrossBridgingId,
+  // getAcrossBridgingId,
+  getEthFlowId,
 ];
 
 async function main() {

--- a/src/scripts/ethflow/getEthFlowId.ts
+++ b/src/scripts/ethflow/getEthFlowId.ts
@@ -1,0 +1,46 @@
+import {
+  ETH_FLOW_ADDRESS,
+  MAX_VALID_TO_EPOCH,
+  OrderKind,
+  OrderSigningUtils,
+  SupportedChainId,
+  WRAPPED_NATIVE_CURRENCIES,
+} from "@cowprotocol/cow-sdk";
+
+import { OrderBalance } from "@cowprotocol/contracts";
+import { getExplorerUrl } from "../../utils";
+
+export async function run() {
+  const chainId = SupportedChainId.MAINNET;
+  const originalOrder = {
+    buyToken: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    receiver: "0x5dde7d9b46d1ae3338a3d9f7d6dc2f214738ed15",
+    sellAmount: "1000000000000000",
+    buyAmount: "1666409",
+    appData:
+      "0xec632b4acad3a229df259d7e20dbe1046eb56c9d31cc304ea6186c746a6a81e3",
+    validTo: 1746218815, // Original valid to
+    feeAmount: "0",
+    kind: OrderKind.SELL,
+    partiallyFillable: false,
+    sellTokenBalance: OrderBalance.ERC20,
+    buyTokenBalance: OrderBalance.ERC20,
+  };
+
+  const { orderId } = await OrderSigningUtils.generateOrderId(
+    chainId,
+    {
+      ...originalOrder,
+      validTo: MAX_VALID_TO_EPOCH,
+      sellToken: WRAPPED_NATIVE_CURRENCIES[chainId].address,
+    },
+    {
+      owner: ETH_FLOW_ADDRESS,
+    }
+  );
+
+  console.log(`🎉 orderId: ${orderId}`);
+  console.log(
+    `See in explorer: https://explorer.cow.fi/orders/${orderId}?tab=overview`
+  );
+}


### PR DESCRIPTION
Gets the orderId for a ethFlow order.

- For the original order: https://etherscan.io/inputdatadecoder?tx=0x1a469996648468371a432b97b4fc405bad0745e187bed245b8f64739be5ecab6 
- I just override the owner and deadline, and then use the utility function exposed by the SDK

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/751d0768-b3ec-45b1-a9f9-9bae9739a6c0" />


We could do a SDK function for ETH flow to make it simpler